### PR TITLE
feat: add Dólar Cripto (Binance P2P) exchange rate

### DIFF
--- a/app/api/binance-rate/route.ts
+++ b/app/api/binance-rate/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+
+async function fetchBinanceP2PPrice(tradeType: "SELL" | "BUY"): Promise<number> {
+  const res = await fetch(
+    "https://p2p.binance.com/bapi/c2c/v2/friendly/c2c/adv/search",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fiat: "ARS",
+        page: 1,
+        rows: 10,
+        tradeType,
+        asset: "USDT",
+        countries: [],
+        additionalKycVerifyFilter: 0,
+        classifies: ["mass", "profession", "fiat_trade"],
+        filterType: "all",
+        followed: false,
+        payTypes: [],
+        periods: [],
+        proMerchantAds: false,
+        publisherType: "merchant",
+        shieldMerchantAds: false,
+        tradedWith: false,
+      }),
+      next: { revalidate: 300 },
+    }
+  );
+
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const data = await res.json();
+  // Saltear Promoted Ads (privilegeDesc !== null) y tomar el primero real
+  const ad = (data?.data ?? []).find((item: any) => !item.privilegeDesc);
+  const price = parseFloat(ad?.adv?.price ?? "0");
+  if (!price) throw new Error("No price found");
+  return price;
+}
+
+export async function GET() {
+  const [sellResult, buyResult] = await Promise.allSettled([
+    fetchBinanceP2PPrice("SELL"),
+    fetchBinanceP2PPrice("BUY"),
+  ]);
+
+  const compra =
+    sellResult.status === "fulfilled" ? sellResult.value : null;
+  const venta =
+    buyResult.status === "fulfilled" ? buyResult.value : null;
+
+  if (compra === null && venta === null) {
+    return NextResponse.json({ error: "No data" }, { status: 502 });
+  }
+
+  return NextResponse.json({
+    compra,
+    venta,
+    updatedAt: new Date().toISOString(),
+  });
+}

--- a/app/api/cotizaciones/route.ts
+++ b/app/api/cotizaciones/route.ts
@@ -13,6 +13,9 @@ interface ExchangeRate {
 let lastSuccessfulRates: ExchangeRate[] | null = null;
 let lastUpdateTime: Date | null = null;
 
+// Cache para el precio Binance P2P
+let lastBinanceRate: ExchangeRate | null = null;
+
 // Datos de fallback iniciales (se actualizarán con valores reales)
 const fallbackRates: ExchangeRate[] = [
   {
@@ -203,10 +206,75 @@ function processExchangeRate(data: any): ExchangeRate {
   return data;
 }
 
+async function fetchBinanceP2P(): Promise<ExchangeRate> {
+  async function fetchSide(tradeType: "SELL" | "BUY"): Promise<number> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+    try {
+      const res = await fetch(
+        "https://p2p.binance.com/bapi/c2c/v2/friendly/c2c/adv/search",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            fiat: "ARS",
+            page: 1,
+            rows: 10,
+            tradeType,
+            asset: "USDT",
+            countries: [],
+            additionalKycVerifyFilter: 0,
+            classifies: ["mass", "profession", "fiat_trade"],
+            filterType: "all",
+            followed: false,
+            payTypes: [],
+            periods: [],
+            proMerchantAds: false,
+            publisherType: "merchant",
+            shieldMerchantAds: false,
+            tradedWith: false,
+          }),
+          signal: controller.signal,
+        }
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      const ad = (data?.data ?? []).find((item: any) => !item.privilegeDesc);
+      const price = parseFloat(ad?.adv?.price ?? "0");
+      if (!price) throw new Error("No price");
+      return price;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  const [sellResult, buyResult] = await Promise.allSettled([
+    fetchSide("SELL"),
+    fetchSide("BUY"),
+  ]);
+
+  const compra =
+    sellResult.status === "fulfilled" ? sellResult.value : 0;
+  const venta =
+    buyResult.status === "fulfilled" ? buyResult.value : 0;
+
+  if (!compra && !venta) throw new Error("Binance P2P: no data");
+
+  return {
+    moneda: "USD",
+    casa: "binance",
+    nombre: "Dólar Cripto (Binance P2P)",
+    compra: compra || venta,
+    venta: venta || compra,
+    fechaActualizacion: new Date().toISOString(),
+  };
+}
+
 export async function GET() {
   try {
-    // Hacer todas las llamadas en paralelo con timeout
-    const results = await Promise.allSettled<ApiResult>(
+    // Hacer todas las llamadas en paralelo con timeout (incluye Binance P2P)
+    const [results, binanceSettled] = await Promise.all([
+      Promise.allSettled<ApiResult>(
       apiCalls.map(async ({ url, name, index }) => {
         try {
           const controller = new AbortController();
@@ -238,7 +306,9 @@ export async function GET() {
           return { success: false, index };
         }
       })
-    );
+      ),
+      Promise.allSettled([fetchBinanceP2P()]),
+    ]);
 
     // Obtener EUR/USD
     let eurUsdRate = 1.08;
@@ -280,13 +350,32 @@ export async function GET() {
       }
     });
 
+    // Agregar Binance P2P al resultado
+    const binanceResult = binanceSettled[0];
+    if (binanceResult.status === "fulfilled") {
+      data.push(binanceResult.value);
+      lastBinanceRate = binanceResult.value;
+      successCount++;
+    } else {
+      console.error("❌ Error fetching Binance P2P:", binanceResult.reason);
+      data.push(lastBinanceRate || {
+        moneda: "USD",
+        casa: "binance",
+        nombre: "Dólar Cripto (Binance P2P)",
+        compra: 0,
+        venta: 0,
+        fechaActualizacion: new Date().toISOString(),
+      });
+      usingFallback = true;
+    }
+
     // Si obtuvimos datos exitosos, actualizar el cache
     if (successCount > 0) {
       lastSuccessfulRates = [...data];
       lastUpdateTime = new Date();
 
       // Actualizar fallbackRates con los nuevos valores exitosos
-      data.forEach((rate, index) => {
+      data.slice(0, fallbackRates.length).forEach((rate, index) => {
         const result = results[index];
         if (isFulfilled(result) && result.value.success) {
           fallbackRates[index] = { ...rate };
@@ -306,7 +395,7 @@ export async function GET() {
       success: true,
       usingFallback,
       successCount,
-      totalApis: apiCalls.length,
+      totalApis: apiCalls.length + 1,
       timestamp: new Date().toISOString(),
       lastSuccessfulUpdate: lastUpdateTime?.toISOString() || null,
       eurUsdRate,
@@ -331,7 +420,7 @@ export async function GET() {
         success: false,
         usingFallback: true,
         successCount: 0,
-        totalApis: apiCalls.length,
+        totalApis: apiCalls.length + 1,
         error: "Error interno del servidor",
         errorDetails:
           process.env.NODE_ENV === "development" ? errorDetails : undefined,

--- a/app/monedas/tipos-de-cambio/page.tsx
+++ b/app/monedas/tipos-de-cambio/page.tsx
@@ -233,7 +233,14 @@ export default function TiposDeCambioPage() {
       {/* Lista de Tipos de Cambio */}
       <div className="max-w-6xl mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          {exchangeRates.map((rate, index) => (
+          {(() => {
+            const binanceIdx = exchangeRates.findIndex(r => r.casa === "binance");
+            if (binanceIdx <= 2 || binanceIdx === -1) return exchangeRates;
+            const arr = [...exchangeRates];
+            const [binance] = arr.splice(binanceIdx, 1);
+            arr.splice(2, 0, binance);
+            return arr;
+          })().map((rate, index) => (
             <Card
               key={`${rate.moneda}-${rate.casa}-${index}`}
               className="hover:shadow-md transition-shadow"

--- a/components/converters/argentinian-currency-converter.tsx
+++ b/components/converters/argentinian-currency-converter.tsx
@@ -25,6 +25,7 @@ const DOLLAR_VARIANTS = [
   { label: "Dólar Bolsa", value: "bolsa", icon: <DollarSign className="h-4 w-4 text-muted-foreground" />, tooltip: "Operaciones bursátiles (MEP)" },
   { label: "Dólar Cripto", value: "cripto", icon: <DollarSign className="h-4 w-4 text-muted-foreground" />, tooltip: "Compra/venta de criptomonedas" },
   { label: "Dólar Mayorista", value: "mayorista", icon: <DollarSign className="h-4 w-4 text-muted-foreground" />, tooltip: "Grandes operaciones entre bancos" },
+  { label: "Binance P2P", value: "binance", icon: <DollarSign className="h-4 w-4 text-muted-foreground" />, tooltip: "Precio USDT/ARS en Binance P2P (primer vendedor real, sin anuncios promocionados)" },
 ]
 const REGIONALS = [
   { label: "Euro", value: "EUR", icon: <Euro className="h-4 w-4 text-muted-foreground" />, tooltip: "Euro oficial en Argentina" },
@@ -82,7 +83,7 @@ export function ArgentinianCurrencyConverter({ exchangeRates, loading }: Argenti
               simboloDestino="ARS$"
               cotizacion={rate.venta || rate.compra}
               fecha={rate.fechaActualizacion}
-              fuente="DolarAPI.com"
+              fuente={selected.value === "binance" ? "Binance P2P" : "DolarAPI.com"}
             />
           </div>
         )}


### PR DESCRIPTION
Fetches USDT/ARS buy and sell prices from Binance P2P, skipping promoted ads. Exposed as a standalone /api/binance-rate endpoint and integrated into /api/cotizaciones alongside existing DolarAPI rates. Shows as 3rd entry in tipos-de-cambio and as a selectable variant in the Argentinian currency converter.